### PR TITLE
Need to have new note form cancel button skip confirmation

### DIFF
--- a/app/views/notes/_form.html.erb
+++ b/app/views/notes/_form.html.erb
@@ -39,7 +39,7 @@
     <nav class="navbar navbar-inverse navbar-fixed-bottom" id="bottom-navbar" role="navigation">
       <div class="container">
         <ul class="nav nav-pills">
-          <li ><%= button_to 'Cancel', (:back), class: "note-bottom-nav-buttons" %></li>
+          <li ><%= button_to 'Cancel', (notes_path), class: "note-bottom-nav-buttons" %></li>
           <li id="visible-to-public-checkbox">
                 <%= f.input :private, label: false, inline_label: "Private Note" %>
                 


### PR DESCRIPTION
Hey Eliot,
When you are in the new note form creating a new note, and you have **not** met all the validations, and you hit the cancel button, the validation message pops up, and you cannot cancel out of the note.  The only way to get out of the screen is to click a link in the navbar.

Is there a way to skip the confirmation being done in this case?  I know that devise offers the `skip_confirmation!` command.  I tried using it, but to no avail.  I even tried creating a custom method in the notes_controller, and enlisting it, but that did not work either.  Couldn't figure out the syntax to force the button to:
1.  skip confirmation, then 
2.  redirect to xyz

Can you please take a look at `app/views/notes/_form.html.erb`, line 42, and tell me what you think?

Thanks,
Harry
